### PR TITLE
Add missing close for file descriptor

### DIFF
--- a/atomic_append.c
+++ b/atomic_append.c
@@ -24,4 +24,10 @@ int main (int argc, char *argv[]) {
       errExit("write byte a");
     }
   }
+
+  if (close(fd) == -1) { 
+      errExit("close output"); 
+  }
+
+  exit(EXIT_SUCCESS);
 }


### PR DESCRIPTION
Add missing close call for file descriptor fd. Also added exit(EXIT_SUCCESS).
